### PR TITLE
Refactor config sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,18 +101,22 @@ SQLite is not designed for concurrent writers over a network filesystem, so try 
 
 ## Configuration
 
-Optional settings live in `$XDG_CONFIG_HOME/toki-note/config.toml` (e.g. `~/.config/toki-note/config.toml`). You can predefine paths for the database and feed outputs:
+Optional settings live in `$XDG_CONFIG_HOME/toki-note/config.toml` (e.g. `~/.config/toki-note/config.toml`). You can predefine paths for the database and feed/import outputs:
 
 ```toml
 database = "/path/to/custom.db"
-ical_output = "/path/to/feed.ics"
-import_source = "/path/to/events.ics"
 
 [rss]
 output = "/path/to/feed.xml"
+
+[ical]
+output = "/path/to/feed.ics"
+
+[import]
+source = "/path/to/events.ics"
 ```
 
-The legacy `rss_output = "..."` key is still supported for backward compatibility.
+The legacy flat keys (`rss_output`, `ical_output`, `import_source`) are still supported for backward compatibility.
 
 This file is read on startup before CLI flags are processed; flags always win over config values.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,9 +7,31 @@ use serde::Deserialize;
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct Config {
     pub database: Option<PathBuf>,
+    #[serde(default)]
+    pub rss: RssSection,
+    #[serde(default)]
+    pub ical: IcalSection,
+    #[serde(default)]
+    pub import: ImportSection,
+    // legacy flat keys
     pub rss_output: Option<PathBuf>,
     pub ical_output: Option<PathBuf>,
     pub import_source: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RssSection {
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct IcalSection {
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct ImportSection {
+    pub source: Option<PathBuf>,
 }
 
 pub fn load_config() -> Result<Config> {
@@ -37,5 +59,25 @@ pub fn resolve_database_path(input: Option<PathBuf>) -> Result<PathBuf> {
         Ok(path)
     } else {
         Ok(PathBuf::from("toki-note.db"))
+    }
+}
+
+impl Config {
+    pub fn rss_output_path(&self) -> Option<PathBuf> {
+        self.rss.output.clone().or_else(|| self.rss_output.clone())
+    }
+
+    pub fn ical_output_path(&self) -> Option<PathBuf> {
+        self.ical
+            .output
+            .clone()
+            .or_else(|| self.ical_output.clone())
+    }
+
+    pub fn import_source_path(&self) -> Option<PathBuf> {
+        self.import
+            .source
+            .clone()
+            .or_else(|| self.import_source.clone())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,19 +22,19 @@ fn main() -> Result<()> {
         Command::Delete(cmd) => delete_event(&mut storage, cmd),
         Command::Rss(mut cmd) => {
             if cmd.output.is_none() {
-                cmd.output = config.rss_output.clone();
+                cmd.output = config.rss_output_path();
             }
             generate_rss(&storage, cmd)
         }
         Command::Ical(mut cmd) => {
             if cmd.output.is_none() {
-                cmd.output = config.ical_output.clone();
+                cmd.output = config.ical_output_path();
             }
             generate_ical(&storage, cmd)
         }
         Command::Import(mut cmd) => {
             if cmd.path.is_none() {
-                cmd.path = config.import_source.clone();
+                cmd.path = config.import_source_path();
             }
             import_ics(&mut storage, cmd)
         }


### PR DESCRIPTION
## Summary

- add `[rss]`, `[ical]`, `[import]` sections so config values are grouped logically
- keep legacy flat keys (`rss_output`, `ical_output`, `import_source`) for backward compatibility
- expose helper methods (`rss_output_path()`, etc.) and update README examples to use the new tables

## Highlights

- config is easier to read/extend; future sections can be added without proliferating flat keys
- CLI still honors existing config files, so users aren’t forced to migrate immediately
- adds a path for future settings (e.g., defaults per feed/import) without changing CLI flags
