### PR TITLE
Add list aliased command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ All-day entries must use explicit `--end` (or omit it for a single day); `--dura
 
 Successful inserts print the assigned row id, which will later be used for listing or deleting records.
 
-List all tracked events, ordered by start time (output uses your system timezone unless overridden with `--tz`):
+List all tracked events, ordered by start time (output uses your system timezone unless overridden with `--tz`). You can also use the `ls` alias:
 
 ```bash
 toki-note list
+# or
+toki-note ls
 ```
 
 Filter for a specific day (UTC boundary for the filter; display timezone may be overridden):

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,7 @@ pub enum Command {
     /// Add a schedule entry
     Add(AddCommand),
     /// List stored schedule entries
+    #[command(alias = "ls")]
     List(ListCommand),
     /// Delete a schedule entry
     Delete(DeleteCommand),

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -37,3 +37,26 @@ fn add_and_list_event() {
         "expected list output to mention title, got:\n{stdout}"
     );
 }
+
+#[test]
+fn ls_alias_works() {
+    let data_home = tempdir().expect("temp dir");
+
+    cargo_bin_cmd!("toki-note")
+        .env("XDG_DATA_HOME", data_home.path())
+        .arg("add")
+        .arg("--title")
+        .arg("Alias test")
+        .arg("--date")
+        .arg("2025-12-02")
+        .arg("--time")
+        .arg("10:00")
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("toki-note")
+        .env("XDG_DATA_HOME", data_home.path())
+        .arg("ls")
+        .assert()
+        .success();
+}


### PR DESCRIPTION
## Summary
- add AGENTS.md
Cargo.lock
Cargo.toml
README.md
assets
src
target
tests as an alias for the  subcommand via clap metadata
- document the shortcut in README so users know both forms are accepted
- extend the CLI integration tests to run  against a temp DB

## Highlights
- reduces keystrokes for a frequently used command without touching DB logic
- keeps coverage up by verifying the alias end-to-end