### PR TITLE
Prepare publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,14 @@
 [package]
 name = "toki-note"
 version = "2025.11.23"
+description = "Tiny SQLite-backed CLI for quickly adding, listing, and exporting personal schedules"
+license = "MIT"
+repository = "https://github.com/katsyoshi/toki-note"
+homepage = "https://github.com/katsyoshi/toki-note"
+documentation = "https://github.com/katsyoshi/toki-note"
+readme = "README.md"
+keywords = ["cli", "calendar", "schedule"]
+categories = ["command-line-utilities"]
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- bump version to 2025.11.23 and add README instructions + version policy
- refresh Cargo.lock
- add Cargo.toml metadata (description, license, repository, etc.) so `cargo publish --dry-run` succeeds

## Highlights
- crates.io release now has proper metadata and installation guidance for users